### PR TITLE
#7 Adds support for parsing JWKS with jwks content-type

### DIFF
--- a/lib/joken_jwks/http_fetcher.ex
+++ b/lib/joken_jwks/http_fetcher.ex
@@ -64,8 +64,7 @@ defmodule JokenJwks.HttpFetcher do
     adapter = opts[:http_adapter] || adapter
 
     middleware = [
-      {M.JSON,
-       decode_content_types: ["application/jwk-set+json"]},
+      {M.JSON, decode_content_types: ["application/jwk-set+json"]},
       M.Logger,
       {M.Retry,
        delay: opts[:http_delay_per_retry] || 500,

--- a/lib/joken_jwks/http_fetcher.ex
+++ b/lib/joken_jwks/http_fetcher.ex
@@ -5,7 +5,7 @@ defmodule JokenJwks.HttpFetcher do
   This must be a standard JWKS URI as per the specification here:
   https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata
 
-  This uses the `Tesla` library to make it easy to test or change the adapter 
+  This uses the `Tesla` library to make it easy to test or change the adapter
   if wanted.
 
   See our tests for an example of mocking the HTTP fetching.
@@ -64,7 +64,8 @@ defmodule JokenJwks.HttpFetcher do
     adapter = opts[:http_adapter] || adapter
 
     middleware = [
-      M.JSON,
+      {M.JSON,
+       decode_content_types: ["application/jwk-set+json"]},
       M.Logger,
       {M.Retry,
        delay: opts[:http_delay_per_retry] || 500,

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -38,7 +38,7 @@ defmodule JokenJwks.IntegrationTest do
 
   test "can parse IdentityServer's JWKS" do
     Strategy.start_link(
-      jwks_url: @application_jwks_set_certs_url,
+      jwks_url: @identity_server_certs_url,
       http_adapter: Tesla.Adapter.Hackney,
       first_fetch_sync: true
     )

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -5,6 +5,7 @@ defmodule JokenJwks.IntegrationTest do
 
   @google_certs_url "https://www.googleapis.com/oauth2/v3/certs"
   @microsoft_certs_url "https://login.microsoftonline.com/common/discovery/v2.0/keys"
+  @identity_server_certs_url "https://demo.identityserver.io/.well-known/openid-configuration/jwks"
 
   defmodule Strategy do
     use JokenJwks.DefaultStrategyTemplate
@@ -29,6 +30,17 @@ defmodule JokenJwks.IntegrationTest do
       http_adapter: Tesla.Adapter.Hackney,
       first_fetch_sync: true,
       explicit_alg: "RS256"
+    )
+
+    assert signers = Strategy.EtsCache.get_signers()
+    assert Enum.count(signers) >= 1
+  end
+
+  test "can parse IdentityServer's JWKS" do
+    Strategy.start_link(
+      jwks_url: @application_jwks_set_certs_url,
+      http_adapter: Tesla.Adapter.Hackney,
+      first_fetch_sync: true
     )
 
     assert signers = Strategy.EtsCache.get_signers()


### PR DESCRIPTION
JWKS servers returning content type 'application/jwk-set+json' are now supported by providing the content-type to the Tesla.Middleware.JSON.
This fixes issue #7 