### PR TITLE
feat: use telemetry for capturing logs

### DIFF
--- a/lib/joken_jwks.ex
+++ b/lib/joken_jwks.ex
@@ -67,20 +67,4 @@ defmodule JokenJwks do
       err -> err
     end
   end
-
-  def log(_, :none, _), do: :ok
-
-  def log(:debug, log_level, msg) do
-    unless Logger.compare_levels(:debug, log_level) == :lt, do: Logger.debug(fn -> msg end)
-  end
-
-  def log(:info, log_level, msg) do
-    unless Logger.compare_levels(:info, log_level) == :lt, do: Logger.info(fn -> msg end)
-  end
-
-  def log(:warn, log_level, msg) do
-    unless Logger.compare_levels(:warn, log_level) == :lt, do: Logger.warn(fn -> msg end)
-  end
-
-  def log(:error, _, msg), do: Logger.error(msg)
 end

--- a/lib/joken_jwks/default_strategy_template.ex
+++ b/lib/joken_jwks/default_strategy_template.ex
@@ -167,7 +167,7 @@ defmodule JokenJwks.DefaultStrategyTemplate do
           |> Keyword.put(:log_level, log_level)
           |> Keyword.put(:jwks_url, url)
 
-        if is_nil(opts[:disable_logs]) || !opts[:disable_logs] do
+        if Keyword.get(opts, :disable_logs, false) do
           JokenJwks.Logger.attach_default_logger(log_level)
         end
 

--- a/lib/joken_jwks/default_strategy_template.ex
+++ b/lib/joken_jwks/default_strategy_template.ex
@@ -167,6 +167,10 @@ defmodule JokenJwks.DefaultStrategyTemplate do
           |> Keyword.put(:log_level, log_level)
           |> Keyword.put(:jwks_url, url)
 
+        if is_nil(opts[:disable_logs]) || !opts[:disable_logs] do
+          JokenJwks.Logger.attach_default_logger(log_level)
+        end
+
         do_init(start?, first_fetch_sync, opts)
       end
 

--- a/lib/joken_jwks/default_strategy_template.ex
+++ b/lib/joken_jwks/default_strategy_template.ex
@@ -226,6 +226,7 @@ defmodule JokenJwks.DefaultStrategyTemplate do
             :telemetry.execute(~w/joken_jwks ets_cache not_needed/a, %{}, %{
               message: "Re-fetching cache is not needed."
             })
+
             :ok
 
           # start re-fetching
@@ -233,6 +234,7 @@ defmodule JokenJwks.DefaultStrategyTemplate do
             :telemetry.execute(~w/joken_jwks ets_cache needed/a, %{}, %{
               message: "Re-fetching cache is needed and will start."
             })
+
             start_fetch_signers(opts[:jwks_url], opts)
         end
       end
@@ -248,21 +250,27 @@ defmodule JokenJwks.DefaultStrategyTemplate do
         with {:ok, keys} <- HttpFetcher.fetch_signers(url, opts),
              {:ok, signers} <- validate_and_parse_keys(keys, opts) do
           :telemetry.execute(~w/joken_jwks fetch_signers success/a, %{}, %{
-            signers: signers, message: "Fetched signers."
+            signers: signers,
+            message: "Fetched signers."
           })
+
           EtsCache.put_signers(signers)
           EtsCache.set_status(:ok)
         else
           {:error, _reason} = err ->
             :telemetry.execute(~w/joken_jwks fetch_signers error/a, %{}, %{
-              error: err, message: "Failed to fetch signers."
+              error: err,
+              message: "Failed to fetch signers."
             })
+
             EtsCache.set_status(:refresh)
 
           err ->
             :telemetry.execute(~w/joken_jwks fetch_signers error/a, %{}, %{
-              error: err, message: "Unexpected error while fetching signers."
+              error: err,
+              message: "Unexpected error while fetching signers."
             })
+
             EtsCache.set_status(:refresh)
         end
       end
@@ -293,6 +301,7 @@ defmodule JokenJwks.DefaultStrategyTemplate do
             key: key,
             message: "Error while parsing a key entry fetched from the network."
           })
+
           {:error, :invalid_key_params}
       end
 

--- a/lib/joken_jwks/default_strategy_template.ex
+++ b/lib/joken_jwks/default_strategy_template.ex
@@ -167,7 +167,7 @@ defmodule JokenJwks.DefaultStrategyTemplate do
           |> Keyword.put(:log_level, log_level)
           |> Keyword.put(:jwks_url, url)
 
-        if Keyword.get(opts, :disable_logs, false) do
+        unless Keyword.get(opts, :disable_logs, false) do
           JokenJwks.Logger.attach_default_logger(log_level)
         end
 

--- a/lib/joken_jwks/default_strategy_template.ex
+++ b/lib/joken_jwks/default_strategy_template.ex
@@ -223,7 +223,9 @@ defmodule JokenJwks.DefaultStrategyTemplate do
         case EtsCache.check_state() do
           # no need to re-fetch
           0 ->
-            :telemetry.execute(~w/joken_jwks ets_cache not_needed/a, %{}, %{message: "Re-fetching cache is not needed."})
+            :telemetry.execute(~w/joken_jwks ets_cache not_needed/a, %{}, %{
+              message: "Re-fetching cache is not needed."
+            })
             :ok
 
           # start re-fetching
@@ -245,16 +247,22 @@ defmodule JokenJwks.DefaultStrategyTemplate do
 
         with {:ok, keys} <- HttpFetcher.fetch_signers(url, opts),
              {:ok, signers} <- validate_and_parse_keys(keys, opts) do
-          :telemetry.execute(~w/joken_jwks fetch_signers success/a, %{}, %{signers: signers, message: "Fetched signers."})
+          :telemetry.execute(~w/joken_jwks fetch_signers success/a, %{}, %{
+            signers: signers, message: "Fetched signers."
+          })
           EtsCache.put_signers(signers)
           EtsCache.set_status(:ok)
         else
           {:error, _reason} = err ->
-            :telemetry.execute(~w/joken_jwks fetch_signers error/a, %{}, %{error: err, message: "Failed to fetch signers."})
+            :telemetry.execute(~w/joken_jwks fetch_signers error/a, %{}, %{
+              error: err, message: "Failed to fetch signers."
+            })
             EtsCache.set_status(:refresh)
 
           err ->
-            :telemetry.execute(~w/joken_jwks fetch_signers error/a, %{}, %{error: err, message: "Unexpected error while fetching signers."})
+            :telemetry.execute(~w/joken_jwks fetch_signers error/a, %{}, %{
+              error: err, message: "Unexpected error while fetching signers."
+            })
             EtsCache.set_status(:refresh)
         end
       end

--- a/lib/joken_jwks/http_fetcher.ex
+++ b/lib/joken_jwks/http_fetcher.ex
@@ -13,7 +13,7 @@ defmodule JokenJwks.HttpFetcher do
   alias Tesla.Middleware, as: M
 
   @log_success ~w/joken_jwks http_fetch_signers success/a
-  @log_error ~w/joken_jwks fetch_signers error/a
+  @log_error ~w/joken_jwks http_fetch_signers error/a
 
   @doc """
   Fetches the JWKS signers from the given url.

--- a/lib/joken_jwks/http_fetcher.ex
+++ b/lib/joken_jwks/http_fetcher.ex
@@ -23,7 +23,7 @@ defmodule JokenJwks.HttpFetcher do
 
   We use `:hackney` as it validates certificates automatically.
   """
-  @spec fetch_signers(binary, boolean) :: {:ok, list} | {:error, atom} | no_return()
+  @spec fetch_signers(binary, map()) :: {:ok, list} | {:error, atom} | no_return()
   def fetch_signers(url, opts) do
     {duration, result} = :timer.tc(Tesla, :get, [new(opts), url])
 

--- a/lib/joken_jwks/logger.ex
+++ b/lib/joken_jwks/logger.ex
@@ -19,7 +19,7 @@ defmodule JokenJwks.Logger do
     ~w/joken_jwks http_fetch_signers error/a,
     ~w/joken_jwks ets_cache not_needed/a,
     ~w/joken_jwks ets_cache needed/a,
-    ~w/joken_jwks parse_signer error/a,
+    ~w/joken_jwks parse_signer error/a
   ]
 
   @doc """

--- a/lib/joken_jwks/logger.ex
+++ b/lib/joken_jwks/logger.ex
@@ -1,0 +1,45 @@
+defmodule JokenJwks.Logger do
+  @moduledoc """
+  Telemetry integration to handle metrics
+  and log them using Logger
+
+  This handler is attached by default when opts[:disable_logs]
+  is nil or false, and prints all infos/errors to console.
+
+  To set your own interceptor for telemetry events,
+  see https://github.com/beam-telemetry/telemetry
+  """
+
+  require Logger
+
+  @events [
+    ~w/joken_jwks fetch_signers success/a,
+    ~w/joken_jwks fetch_signers error/a,
+    ~w/joken_jwks http_fetch_signers success/a,
+    ~w/joken_jwks http_fetch_signers error/a,
+    ~w/joken_jwks ets_cache not_needed/a,
+    ~w/joken_jwks ets_cache needed/a,
+    ~w/joken_jwks parse_signer error/a,
+  ]
+
+  @doc """
+  Default logger is attached when there is
+  no explicit config for disabling it and
+  splits error, success and debug events
+  """
+  def attach_default_logger(level) do
+    :telemetry.attach_many("jokenjwks-default-logger", @events, &handle_event/4, level)
+  end
+
+  defp handle_event([:joken_jwks, :ets_cache, message], _measure, metadata, _level) do
+    Logger.debug(fn -> "ets_cache #{message}: #{metadata[:message]}" end)
+  end
+
+  defp handle_event([:joken_jwks, function, :error], _measure, metadata, _level) do
+    Logger.warn("error in #{function}: #{inspect(metadata)}")
+  end
+
+  defp handle_event([:joken_jwks, function, :success], _measure, metadata, _level) do
+    Logger.info("success in #{function}: #{inspect(metadata)}")
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -43,6 +43,7 @@ defmodule JokenJwks.MixProject do
       {:jason, "~> 1.1"},
       {:tesla, "~> 1.2"},
       {:hackney, "~> 1.15.2"},
+      {:telemetry, "~> 0.4.1"},
 
       # docs
       {:ex_doc, "~> 0.19", only: :dev, runtime: false},

--- a/mix.lock
+++ b/mix.lock
@@ -24,6 +24,7 @@
   "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm"},
   "parse_trans": {:hex, :parse_trans, "3.3.0", "09765507a3c7590a784615cfd421d101aec25098d50b89d7aa1d66646bc571c1", [:rebar3], [], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.5", "6eaf7ad16cb568bb01753dbbd7a95ff8b91c7979482b95f38443fe2c8852a79b", [:make, :mix, :rebar3], [], "hexpm"},
+  "telemetry": {:hex, :telemetry, "0.4.1", "ae2718484892448a24470e6aa341bc847c3277bfb8d4e9289f7474d752c09c7f", [:rebar3], [], "hexpm"},
   "tesla": {:hex, :tesla, "1.2.1", "864783cc27f71dd8c8969163704752476cec0f3a51eb3b06393b3971dc9733ff", [:mix], [{:exjsx, ">= 3.0.0", [hex: :exjsx, repo: "hexpm", optional: true]}, {:fuse, "~> 2.4", [hex: :fuse, repo: "hexpm", optional: true]}, {:hackney, "~> 1.6", [hex: :hackney, repo: "hexpm", optional: true]}, {:ibrowse, "~> 4.4.0", [hex: :ibrowse, repo: "hexpm", optional: true]}, {:jason, ">= 1.0.0", [hex: :jason, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}, {:poison, ">= 1.0.0", [hex: :poison, repo: "hexpm", optional: true]}], "hexpm"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.4.1", "d869e4c68901dd9531385bb0c8c40444ebf624e60b6962d95952775cac5e90cd", [:rebar3], [], "hexpm"},
   "unsafe": {:hex, :unsafe, "1.0.1", "a27e1874f72ee49312e0a9ec2e0b27924214a05e3ddac90e91727bc76f8613d8", [:mix], [], "hexpm"},

--- a/test/default_strategy_template_test.exs
+++ b/test/default_strategy_template_test.exs
@@ -232,6 +232,7 @@ defmodule JokenJwks.DefaultStrategyTest do
     end)
 
     TestToken.Strategy.start_link(jwks_url: "http://jwks", first_fetch_sync: true)
+
     # no sleep here
 
     token = TestToken.generate_and_sign!(%{}, TestUtils.create_signer_with_kid("id1"))


### PR DESCRIPTION
In order to enable users of this library to do their own error capturing logic, this PR replaces all calls to the current application logger (based on Logger) with [telemetry library](https://github.com/beam-telemetry/telemetry), and also implements a default listener to convert telemetry metrics into Logger's message.

In this PR I also didn't mean to replace logged texts, so all telemetry calls include a `message` key with old logger argument.

Also, only http call is collection duration metrics (through :timer.tc)