### PR TITLE
feat: telemetry middleware for tesla

### DIFF
--- a/lib/joken_jwks/default_strategy_template.ex
+++ b/lib/joken_jwks/default_strategy_template.ex
@@ -161,11 +161,14 @@ defmodule JokenJwks.DefaultStrategyTemplate do
         url = opts[:jwks_url] || raise "No url set for fetching JWKS!"
         EtsCache.new()
 
+        telemetry_prefix = Keyword.get(opts, :telemetry_prefix, __MODULE__)
+
         opts =
           opts
           |> Keyword.put(:time_interval, time_interval)
           |> Keyword.put(:log_level, log_level)
           |> Keyword.put(:jwks_url, url)
+          |> Keyword.put(:telemetry_prefix, telemetry_prefix)
 
         do_init(start?, first_fetch_sync, opts)
       end

--- a/lib/joken_jwks/http_fetcher.ex
+++ b/lib/joken_jwks/http_fetcher.ex
@@ -21,7 +21,7 @@ defmodule JokenJwks.HttpFetcher do
 
   We use `:hackney` as it validates certificates automatically.
   """
-  @spec fetch_signers(binary, boolean) :: {:ok, list} | {:error, atom} | no_return()
+  @spec fetch_signers(binary, map()) :: {:ok, list} | {:error, atom} | no_return()
   def fetch_signers(url, opts) do
     log_level = opts[:log_level]
 

--- a/lib/joken_jwks/http_fetcher.ex
+++ b/lib/joken_jwks/http_fetcher.ex
@@ -10,6 +10,7 @@ defmodule JokenJwks.HttpFetcher do
 
   See our tests for an example of mocking the HTTP fetching.
   """
+  alias JokenJwks.Middleware.Telemetry, as: JokenJwksTelemetry
   alias Tesla.Middleware, as: M
 
   @doc """
@@ -66,6 +67,7 @@ defmodule JokenJwks.HttpFetcher do
     middleware = [
       {M.JSON, decode_content_types: ["application/jwk-set+json"]},
       M.Logger,
+      {JokenJwksTelemetry, telemetry_prefix: opts[:telemetry_prefix]},
       {M.Retry,
        delay: opts[:http_delay_per_retry] || 500,
        max_retries: opts[:http_max_retries_per_fetch] || 10}

--- a/lib/joken_jwks/middleware/telemetry.ex
+++ b/lib/joken_jwks/middleware/telemetry.ex
@@ -1,8 +1,8 @@
 defmodule JokenJwks.Middleware.Telemetry do
   @moduledoc """
-  Middleware used on Tesla calls to intercept
-  request time and response content and
-  report to :telemetry library
+  Tesla Middleware for publishing telemetry events.
+
+  This middleware reports status and request time/response useful for monitoring the JWKS provider.
   """
 
   @behaviour Tesla.Middleware

--- a/lib/joken_jwks/middleware/telemetry.ex
+++ b/lib/joken_jwks/middleware/telemetry.ex
@@ -1,0 +1,20 @@
+defmodule JokenJwks.Middleware.Telemetry do
+  @moduledoc """
+  Middleware used on Tesla calls to intercept
+  request time and response content and
+  report to :telemetry library
+  """
+
+  @behaviour Tesla.Middleware
+
+  @impl Tesla.Middleware
+  def call(env, next, opts) do
+    {time, res} = :timer.tc(Tesla, :run, [env, next])
+
+    :telemetry.execute([opts[:telemetry_prefix], :joken_jwks, :request], %{request_time: time}, %{
+      result: res
+    })
+
+    res
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -43,6 +43,7 @@ defmodule JokenJwks.MixProject do
       {:jason, "~> 1.1"},
       {:tesla, "~> 1.2"},
       {:hackney, "~> 1.15.2"},
+      {:telemetry, "~> 0.4.1"},
 
       # docs
       {:ex_doc, "~> 0.19", only: :dev, runtime: false},

--- a/mix.lock
+++ b/mix.lock
@@ -24,6 +24,7 @@
   "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm"},
   "parse_trans": {:hex, :parse_trans, "3.3.0", "09765507a3c7590a784615cfd421d101aec25098d50b89d7aa1d66646bc571c1", [:rebar3], [], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.5", "6eaf7ad16cb568bb01753dbbd7a95ff8b91c7979482b95f38443fe2c8852a79b", [:make, :mix, :rebar3], [], "hexpm"},
+  "telemetry": {:hex, :telemetry, "0.4.1", "ae2718484892448a24470e6aa341bc847c3277bfb8d4e9289f7474d752c09c7f", [:rebar3], [], "hexpm"},
   "tesla": {:hex, :tesla, "1.2.1", "864783cc27f71dd8c8969163704752476cec0f3a51eb3b06393b3971dc9733ff", [:mix], [{:exjsx, ">= 3.0.0", [hex: :exjsx, repo: "hexpm", optional: true]}, {:fuse, "~> 2.4", [hex: :fuse, repo: "hexpm", optional: true]}, {:hackney, "~> 1.6", [hex: :hackney, repo: "hexpm", optional: true]}, {:ibrowse, "~> 4.4.0", [hex: :ibrowse, repo: "hexpm", optional: true]}, {:jason, ">= 1.0.0", [hex: :jason, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}, {:poison, ">= 1.0.0", [hex: :poison, repo: "hexpm", optional: true]}], "hexpm"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.4.1", "d869e4c68901dd9531385bb0c8c40444ebf624e60b6962d95952775cac5e90cd", [:rebar3], [], "hexpm"},
   "unsafe": {:hex, :unsafe, "1.0.1", "a27e1874f72ee49312e0a9ec2e0b27924214a05e3ddac90e91727bc76f8613d8", [:mix], [], "hexpm"},

--- a/test/default_strategy_template_test.exs
+++ b/test/default_strategy_template_test.exs
@@ -232,6 +232,7 @@ defmodule JokenJwks.DefaultStrategyTest do
     end)
 
     TestToken.Strategy.start_link(jwks_url: "http://jwks", first_fetch_sync: true)
+
     # no sleep here
 
     token = TestToken.generate_and_sign!(%{}, TestUtils.create_signer_with_kid("id1"))


### PR DESCRIPTION
This PR is a re-implementation of #11, where I wrote a lot of collectors for `telemetry` library.

In this one is used a middleware for Tesla that reports execution time and http results, even for error and success. Than the consumer is responsible for interpreting that.

By default, the event assumes the module that `use`s the DefaultStrategyTemplate as prefix, as the example: `[MyProject.Authentication.MyJwksStrategy, :joken_jwks, :request]`.