### PR TITLE
fix: change fetch signers spec

### DIFF
--- a/lib/joken_jwks/http_fetcher.ex
+++ b/lib/joken_jwks/http_fetcher.ex
@@ -21,7 +21,7 @@ defmodule JokenJwks.HttpFetcher do
 
   We use `:hackney` as it validates certificates automatically.
   """
-  @spec fetch_signers(binary, map()) :: {:ok, list} | {:error, atom} | no_return()
+  @spec fetch_signers(binary, keyword()) :: {:ok, list} | {:error, atom} | no_return()
   def fetch_signers(url, opts) do
     log_level = opts[:log_level]
 


### PR DESCRIPTION
Before the last PR (https://github.com/joken-elixir/joken_jwks/pull/12/files#diff-76b9a3973bb2b8ef8e221cc6cfa7cd8eR24), this typespec was wrongly set as `boolean` and it was changed to `map` (also wrong).

This PR changes it to the correct type: `keyword`.