### PR TITLE
Address unmatched return warnings from Dialyzer

### DIFF
--- a/lib/joken_jwks/default_strategy_template.ex
+++ b/lib/joken_jwks/default_strategy_template.ex
@@ -102,7 +102,7 @@ defmodule JokenJwks.DefaultStrategyTemplate do
 
         @doc "Starts ETS cache"
         def new do
-          :ets.new(__MODULE__, [
+          __MODULE__ = :ets.new(__MODULE__, [
             :set,
             :public,
             :named_table,
@@ -180,7 +180,7 @@ defmodule JokenJwks.DefaultStrategyTemplate do
             Task.start_link(__MODULE__, :poll, [opts])
 
           should_start ->
-            start_fetch_signers(opts[:jwks_url], opts)
+            {:ok, _} = start_fetch_signers(opts[:jwks_url], opts)
             Task.start_link(__MODULE__, :poll, [opts])
 
           true ->
@@ -213,7 +213,7 @@ defmodule JokenJwks.DefaultStrategyTemplate do
         receive do
         after
           interval ->
-            check_fetch(opts)
+            _ = check_fetch(opts)
             poll(opts)
         end
       end


### PR DESCRIPTION
If you `use JokenJwks.DefaultStrategyTemplate` in your own code and run dialyzer
to check with `-Wunmatched_returns`, three warnings appear on the line where
`use` was put. Adding `location: :keep` to the `quote` in
`JokenJwks.DefaultStrategyTemplate` reveals the following lines:

```
  lib/joken_jwks/default_strategy_template.ex:105: Expression produces a value of type
          atom() | ets:tid(), but this value is unmatched
  lib/joken_jwks/default_strategy_template.ex:183: Expression produces a value of type
          {'ok', pid()}, but this value is unmatched
  lib/joken_jwks/default_strategy_template.ex:216: Expression produces a value of type
          'ok' | {'ok', pid()}, but this value is unmatched
```

This commit resolves the above warnings as following (respectively):

* The call to `:ets.new/2` uses the `:named_table` option, and so should always
  return the atom that was passed as the table name, namely `__MODULE__`.
* The call to `start_fetch_signers/2` has the same return type as
  `Task.start/1`, which is `{:ok, pid()}`, so we match on `{:ok, _}`.
* The call to `check_fetch` could return `:ok` or `{:ok, pid()}` based on the
  branches of the `case` expression inside the function. Since there weren't any
  simple ways to resolve this, I chose to match with `_`.