### PR TITLE
Update telemetry to accept version 1.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -43,7 +43,7 @@ defmodule JokenJwks.MixProject do
       {:jason, "~> 1.2"},
       {:tesla, "~> 1.3"},
       {:hackney, "~> 1.17.0"},
-      {:telemetry, "~> 0.4.2"},
+      {:telemetry, "~> 0.4.2 or ~> 1.0"},
 
       # docs
       {:ex_doc, "~> 0.22", only: :dev, runtime: false},


### PR DESCRIPTION
Between versions 0.4.2 and 1.0, the API did not change.

- The bump from 0.4.2 to 0.4.3 added a new `telemetry_span_context` metadata to all span events.
- The bump from 0.4.3 to 1.0 was empty; it only existed to mark the stability of the API.

[Changelog](https://github.com/beam-telemetry/telemetry/blob/main/CHANGELOG.md)
[Hex diff](https://diff.hex.pm/diff/telemetry/0.4.2..1.0.0)