### PR TITLE
Update Hackney spec to include 1.18 versions

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -40,7 +40,7 @@ defmodule JokenJwks.MixProject do
       {:joken, "~> 2.4"},
       {:jason, "~> 1.2"},
       {:tesla, "~> 1.4"},
-      {:hackney, "~> 1.17.4 or ~> 1.18"},
+      {:hackney, "~> 1.17.4 or ~> 1.18.0"},
       {:telemetry, "~> 0.4.2 or ~> 1.0"},
 
       # docs


### PR DESCRIPTION
Update dependency specification for Hackney to support 1.18 versions (currently only 1.18.0 is out). The [diff from 1.17.4 to 1.18.0](https://diff.hex.pm/diff/hackney/1.17.4..1.18.0) is pretty small, updating the ca bundle and an update to pooling.

I ran the external tests to ensure that the Hackney usage here still works :+1: