### PR TITLE
use GenServer instead of Task for the default strategy process

### DIFF
--- a/lib/joken_jwks/default_strategy_template.ex
+++ b/lib/joken_jwks/default_strategy_template.ex
@@ -78,8 +78,6 @@ defmodule JokenJwks.DefaultStrategyTemplate do
     - `name`: name of the GenServer. Default is __MODULE__.
       It can be any acceptable values in [Name registration section](https://hexdocs.pm/elixir/1.13.4/GenServer.html#module-name-registration){:target=_blank} of the GenServer HexDoc
 
-    - `ets_name`: name of the `:ets` table for `EtsCache`. Default is __MODULE__. Has to be atom.
-
   ### Examples
 
       defmodule JokenExample.MyStrategy do
@@ -199,7 +197,6 @@ defmodule JokenJwks.DefaultStrategyTemplate do
         [_, _, {:jws, {:alg, algs}}] = JOSE.JWA.supports()
 
         name = if is_nil(opts[:name]), do: __MODULE__, else: opts[:name]
-        ets_name = if is_nil(opts[:ets_name]), do: __MODULE__, else: opts[:ets_name]
 
         opts =
           opts
@@ -210,7 +207,6 @@ defmodule JokenJwks.DefaultStrategyTemplate do
           |> Keyword.put(:jws_supported_algs, algs)
           |> Keyword.put(:should_start, start?)
           |> Keyword.put(:first_fetch_sync, first_fetch_sync)
-          |> Keyword.put(:ets_name, ets_name)
 
         GenServer.start_link(__MODULE__, opts, name: name)
       end

--- a/lib/joken_jwks/default_strategy_template.ex
+++ b/lib/joken_jwks/default_strategy_template.ex
@@ -75,9 +75,6 @@ defmodule JokenJwks.DefaultStrategyTemplate do
     - `http_delay_per_retry` (`pos_integer()` - default `500`): passed to
       `Tesla.Middleware.Retry`
 
-    - `name`: name of the GenServer. Default is __MODULE__.
-      It can be any acceptable values in [Name registration section](https://hexdocs.pm/elixir/1.13.4/GenServer.html#module-name-registration){:target=_blank} of the GenServer HexDoc
-
   ### Examples
 
       defmodule JokenExample.MyStrategy do
@@ -196,8 +193,6 @@ defmodule JokenJwks.DefaultStrategyTemplate do
 
         [_, _, {:jws, {:alg, algs}}] = JOSE.JWA.supports()
 
-        name = if is_nil(opts[:name]), do: __MODULE__, else: opts[:name]
-
         opts =
           opts
           |> Keyword.put(:time_interval, time_interval)
@@ -208,7 +203,7 @@ defmodule JokenJwks.DefaultStrategyTemplate do
           |> Keyword.put(:should_start, start?)
           |> Keyword.put(:first_fetch_sync, first_fetch_sync)
 
-        GenServer.start_link(__MODULE__, opts, name: name)
+        GenServer.start_link(__MODULE__, opts, name: __MODULE__)
       end
 
       # Server (callbacks)


### PR DESCRIPTION
Polling is a bit more idiomatic when done inside GenServer.
Also, having GenServer allows for dynamic spinning up of strategy modules, which is something I need at work.

This is still "locked" to spin up pre-defined strategy modules.

However, it's closer than before (since now it is in GenServer) to use as a template to build custom dynamic strategies - such as if you are building a multi-tenant OAuth2 authentication server. 

In addition, I changed the API calls to be synchronous, as you'd still want to process the outcome of the current API call response before you schedule another API call to prevent any possibility of firing the next API call even when processing the current one didn't finish yet.