### PR TITLE
UPDATE: EtsCache.new() to create only if table doesn't exist

### DIFF
--- a/lib/joken_jwks/ets_cache.ex
+++ b/lib/joken_jwks/ets_cache.ex
@@ -1,17 +1,23 @@
 defmodule JokenJwks.DefaultStrategyTemplate.EtsCache do
   @moduledoc "Simple ETS counter based state machine"
 
-  @doc "Starts ETS cache"
+  @doc "Starts ETS cache - will only create if table doesn't exist already"
   def new(module) do
-    :ets.new(name(module), [
-      :set,
-      :public,
-      :named_table,
-      read_concurrency: true,
-      write_concurrency: true
-    ])
+    case :ets.whereis(name(module)) do
+      :undefined ->
+        :ets.new(name(module), [
+          :set,
+          :public,
+          :named_table,
+          read_concurrency: true,
+          write_concurrency: true
+        ])
 
-    :ets.insert(name(module), {:counter, 0})
+        :ets.insert(name(module), {:counter, 0})
+
+      _ ->
+        true
+    end
   end
 
   @doc "Returns 0 - no need to fetch signers or 1 - need to fetch"

--- a/test/default_strategy_template_test.exs
+++ b/test/default_strategy_template_test.exs
@@ -285,6 +285,14 @@ defmodule JokenJwks.DefaultStrategyTest do
     assert Enum.count(EtsCache.get_signers(TestToken.Strategy)[:signers]) == 0
   end
 
+  test "ets table creation attempt should not error out even if table already exists" do
+    setup_jwks()
+    EtsCache.new(TestToken.Strategy)
+
+    token = TestToken.generate_and_sign!(%{}, TestUtils.create_signer_with_kid("id2"))
+    assert {:ok, %{}} == TestToken.verify_and_validate(token)
+  end
+
   def setup_jwks(time_interval \\ 1_000) do
     expect_call(fn %{url: "http://jwks"} ->
       {:ok, json(%{"keys" => [TestUtils.build_key("id1"), TestUtils.build_key("id2")]})}


### PR DESCRIPTION
Fix for https://github.com/joken-elixir/joken_jwks/issues/40#issuecomment-2276466555, where we won't create the ETS table if it already exists.