### PR TITLE
Fix initial async load of signers

### DIFF
--- a/lib/joken_jwks/default_strategy_template.ex
+++ b/lib/joken_jwks/default_strategy_template.ex
@@ -192,13 +192,16 @@ defmodule JokenJwks.DefaultStrategyTemplate do
     # init callback runs in the server process already
     EtsCache.new(module)
 
-    if Keyword.get(opts, :first_fetch_sync) do
+    first_fetch_sync = Keyword.get(opts, :first_fetch_sync)
+
+    if first_fetch_sync do
       fetch_signers(module, opts[:jwks_url], opts)
     end
 
     if Keyword.get(opts, :should_start, true) do
       EtsCache.set_status(module, :refresh)
-      schedule_check_fetch(module, opts[:time_interval])
+      initial_interval = if first_fetch_sync, do: opts[:time_interval], else: 0
+      schedule_check_fetch(module, initial_interval)
       {:ok, opts}
     else
       :ignore


### PR DESCRIPTION
Hey! 

Seems like there's a regression from `v1.6` where the initial async signers load only happens after one full interval, which by default is quite time window in which all JWT verifications are down. 

This PR makes the initial async signers load instant, like it was in `v1.6`. 